### PR TITLE
Added solution for building package directly from git

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if pwd | grep node_modules ; then
+  cd ../..
+  mv node_modules/ngx-treeview tmp-ngx-treeview
+  cd tmp-ngx-treeview
+  npm install --ignore-scripts
+  npm rebuild node-sass
+  npm run build
+  cd ..
+  mv tmp-ngx-treeview/dist/src node_modules/ngx-treeview
+  mv tmp-ngx-treeview node_modules/ngx-treeview/source
+fi

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test-coverage": "ng test --watch=false --code-coverage",
     "e2e": "ng e2e",
     "prebuild": "rimraf tmp dist",
+    "preinstall": "./install.sh",
     "build": "gulp inline-templates && ngc -p tsconfig-lib.json && copyfiles package.json README.md LICENSE dist",
     "postbuild": "rimraf tmp",
     "pub": "npm run build && npm publish dist",
@@ -49,6 +50,7 @@
     "lodash": "4.17.10"
   },
   "devDependencies": {
+    "webpack": "4.24.0",
     "@angular-devkit/build-angular": "0.8.0",
     "@angular/cli": "6.2.1",
     "@angular/common": "6.1.7",


### PR DESCRIPTION
This pull request allows us to build ngx-treeview directly from git by fetching it and building in preinstall hook. We have to build it outside of `node_modules` folder because of angular compiler limitations - when in `node_modules` directory ngc creates only metadata files.