### PR TITLE
feature(improvement): Make parent selectable by itself

### DIFF
--- a/src/lib/treeview-item.ts
+++ b/src/lib/treeview-item.ts
@@ -142,16 +142,21 @@ export class TreeviewItem {
     getSelection(): TreeviewSelection {
         let checkedItems: TreeviewItem[] = [];
         let uncheckedItems: TreeviewItem[] = [];
-        if (isNil(this.internalChildren)) {
-            if (this.internalChecked) {
-                checkedItems.push(this);
-            } else {
-                uncheckedItems.push(this);
-            }
+
+        if (this.internalChecked) {
+          checkedItems.push(this);
         } else {
-            const selection = TreeviewHelper.concatSelection(this.internalChildren, checkedItems, uncheckedItems);
-            checkedItems = selection.checked;
-            uncheckedItems = selection.unchecked;
+          uncheckedItems.push(this);
+        }
+
+        if (!isNil(this.internalChildren)) {
+          const selection = TreeviewHelper.concatSelection(
+            this.internalChildren,
+            checkedItems,
+            uncheckedItems
+          );
+          checkedItems = selection.checked;
+          uncheckedItems = selection.unchecked;
         }
 
         return {


### PR DESCRIPTION
Description:
Allows for the parent of children to be selectable by itself
Fix for #197 https://github.com/leovo2708/ngx-treeview/issues/197

Current implementation ignores the selection of a parent so never checks if its checkbox has been selected