### PR TITLE
feature(improvement): Make parent selectable by itself

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if pwd | grep node_modules ; then
+  cd ../..
+  mv node_modules/ngx-treeview tmp-ngx-treeview
+  cd tmp-ngx-treeview
+  npm install --ignore-scripts
+  npm rebuild node-sass
+  npm run build
+  cd ..
+  mv tmp-ngx-treeview/dist/src node_modules/ngx-treeview
+  mv tmp-ngx-treeview node_modules/ngx-treeview/source
+fi

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test-coverage": "ng test --watch=false --code-coverage",
     "e2e": "ng e2e",
     "prebuild": "rimraf tmp dist",
+    "preinstall": "./install.sh",
     "build": "gulp inline-templates && ngc -p tsconfig-lib.json && copyfiles package.json README.md LICENSE dist",
     "postbuild": "rimraf tmp",
     "pub": "npm run build && npm publish dist",
@@ -49,6 +50,7 @@
     "lodash": "4.17.10"
   },
   "devDependencies": {
+    "webpack": "4.24.0",
     "@angular-devkit/build-angular": "0.8.0",
     "@angular/cli": "6.2.1",
     "@angular/common": "6.1.7",

--- a/src/lib/treeview-item.spec.ts
+++ b/src/lib/treeview-item.spec.ts
@@ -233,7 +233,7 @@ describe('TreeviewItem', () => {
                 parentItem.children = [childItem1, childItem2];
                 const selection = parentItem.getSelection();
                 expect(selection.checkedItems).toEqual([childItem1, childItem21]);
-                expect(selection.uncheckedItems).toEqual([childItem22]);
+                expect(selection.uncheckedItems).toEqual([parentItem, childItem2, childItem22]);
             });
         });
     });

--- a/src/lib/treeview-item.ts
+++ b/src/lib/treeview-item.ts
@@ -142,16 +142,21 @@ export class TreeviewItem {
     getSelection(): TreeviewSelection {
         let checkedItems: TreeviewItem[] = [];
         let uncheckedItems: TreeviewItem[] = [];
-        if (isNil(this.internalChildren)) {
-            if (this.internalChecked) {
-                checkedItems.push(this);
-            } else {
-                uncheckedItems.push(this);
-            }
+
+        if (this.internalChecked) {
+          checkedItems.push(this);
         } else {
-            const selection = TreeviewHelper.concatSelection(this.internalChildren, checkedItems, uncheckedItems);
-            checkedItems = selection.checked;
-            uncheckedItems = selection.unchecked;
+          uncheckedItems.push(this);
+        }
+
+        if (!isNil(this.internalChildren)) {
+          const selection = TreeviewHelper.concatSelection(
+            this.internalChildren,
+            checkedItems,
+            uncheckedItems
+          );
+          checkedItems = selection.checked;
+          uncheckedItems = selection.unchecked;
         }
 
         return {

--- a/src/lib/treeview-item.ts
+++ b/src/lib/treeview-item.ts
@@ -22,8 +22,10 @@ export class TreeviewItem {
     private internalChildren: TreeviewItem[];
     text: string;
     value: any;
+    decoupleChildFromParent: boolean;
 
-    constructor(item: TreeItem, autoCorrectChecked = false) {
+    constructor(item: TreeItem, autoCorrectChecked = false, decoupleChildFromParent = false) {
+        this.decoupleChildFromParent = decoupleChildFromParent;
         if (isNil(item)) {
             throw new Error('Item must be defined');
         }
@@ -48,7 +50,7 @@ export class TreeviewItem {
                     child.disabled = true;
                 }
 
-                return new TreeviewItem(child);
+                return new TreeviewItem(child, autoCorrectChecked, this.decoupleChildFromParent);
             });
         }
 
@@ -134,7 +136,9 @@ export class TreeviewItem {
                         }
                     }
                 });
-                this.internalChecked = checked;
+                if (!this.decoupleChildFromParent) {
+                    this.internalChecked = checked;
+                }
             }
         }
     }

--- a/src/lib/treeview.component.spec.ts
+++ b/src/lib/treeview.component.spec.ts
@@ -408,7 +408,7 @@ describe('TreeviewComponent', () => {
         it('should raise selectedChange when binding items', () => {
             expect(selectedChangeSpy.calls.any()).toBeTruthy();
             const args = selectedChangeSpy.calls.mostRecent().args;
-            expect(args[0]).toEqual([111, 112, 12, 2]);
+            expect(args[0]).toEqual([1, 11, 111, 112, 12, 2]);
         });
 
         it('should have "All" checkbox is checked', () => {
@@ -554,7 +554,7 @@ describe('TreeviewComponent', () => {
                 it('should raise event selectedChange', () => {
                     expect(selectedChangeSpy.calls.any()).toBeTruthy();
                     const args = selectedChangeSpy.calls.mostRecent().args;
-                    expect(args[0]).toEqual([111, 112, 2]);
+                    expect(args[0]).toEqual([11, 111, 112, 2]);
                 });
             });
 


### PR DESCRIPTION
Code pulled from @Megagyger fix from original repository, with backmerge allowing pulling from github.

Description:
Allows for the parent of children to be selectable by itself

Current implementation ignores the selection of a parent so never checks if its checkbox has been selected